### PR TITLE
[M3] WIP Use the FxA Rust backend behind a pref

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1418,6 +1418,9 @@ pref("browser.uiCustomization.state", "");
 // A restart is mandatory after flipping that preference.
 pref("identity.fxaccounts.enabled", true);
 
+// Use of the experimental Rust backend.
+pref("identity.fxaccounts.useExperimentalRustClient", true /* TODO FALSE! */);
+
 // The remote FxA root content URL. Must use HTTPS.
 pref("identity.fxaccounts.remote.root", "https://accounts.firefox.com/");
 

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1419,7 +1419,7 @@ pref("browser.uiCustomization.state", "");
 pref("identity.fxaccounts.enabled", true);
 
 // Use of the Rust backend vs JS backend
-pref("identity.fxaccounts.useRustBackend", false);
+pref("identity.fxaccounts.useRustBackend", true /* TODO: make false later */);
 
 // The remote FxA root content URL. Must use HTTPS.
 pref("identity.fxaccounts.remote.root", "https://accounts.firefox.com/");

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1418,8 +1418,8 @@ pref("browser.uiCustomization.state", "");
 // A restart is mandatory after flipping that preference.
 pref("identity.fxaccounts.enabled", true);
 
-// Use of the experimental Rust backend.
-pref("identity.fxaccounts.useExperimentalRustClient", true /* TODO FALSE! */);
+// Use of the Rust backend vs JS backend
+pref("identity.fxaccounts.useRustBackend", false);
 
 // The remote FxA root content URL. Must use HTTPS.
 pref("identity.fxaccounts.remote.root", "https://accounts.firefox.com/");

--- a/browser/base/content/browser-sync.js
+++ b/browser/base/content/browser-sync.js
@@ -23,6 +23,12 @@ ChromeUtils.defineModuleGetter(
   "resource://services-sync/main.js"
 );
 
+XPCOMUtils.defineLazyPreferenceGetter(
+  this,
+  "RUST_BACKEND",
+  "identity.fxaccounts.useRustBackend"
+);
+
 const MIN_STATUS_ANIMATION_DURATION = 1600;
 
 var gSync = {
@@ -735,7 +741,12 @@ var gSync = {
   },
 
   async openFxAEmailFirstPage(entryPoint) {
-    const url = await FxAccounts.config.promiseConnectAccountURI(entryPoint);
+    let url;
+    if (RUST_BACKEND) {
+      url = await FxAccounts.config.promiseConnectAccountOAuthURI();
+    } else {
+      url = await FxAccounts.config.promiseConnectAccountURI(entryPoint);
+    }
     switchToTabHavingURI(url, true, { replaceQueryString: true });
   },
 

--- a/services/fxaccounts/FxAccounts.jsm
+++ b/services/fxaccounts/FxAccounts.jsm
@@ -40,6 +40,7 @@ const {
   FXA_PWDMGR_REAUTH_WHITELIST,
   FXA_PWDMGR_SECURE_FIELDS,
   FX_OAUTH_CLIENT_ID,
+  FX_OAUTH_WEBCHANNEL_REDIRECT,
   KEY_LIFETIME,
   ON_ACCOUNT_STATE_CHANGE_NOTIFICATION,
   ONLOGIN_NOTIFICATION,
@@ -127,8 +128,14 @@ XPCOMUtils.defineLazyPreferenceGetter(
 
 XPCOMUtils.defineLazyPreferenceGetter(
   this,
+  "ROOT_URL",
+  "identity.fxaccounts.remote.root"
+);
+
+XPCOMUtils.defineLazyPreferenceGetter(
+  this,
   "USE_RUST",
-  "identity.fxaccounts.useExperimentalRustClient",
+  "identity.fxaccounts.useRustBackend",
   null,
   null,
   val => (AppConstants.NIGHTLY_BUILD ? val : false) // On non-nightly builds the pref shouldn't even work.
@@ -390,6 +397,15 @@ function copyObjectProperties(from, to, thisObj, keys) {
 class FxAccounts {
   constructor(mocks = null) {
     this._internal = new FxAccountsInternal();
+    if (RUST_BACKEND) {
+      // FxAccounts functionality with the Rust backend.
+      this._rustFxAccount = new RustFxAccount({
+        fxaServer: ROOT_URL,
+        clientId: FX_OAUTH_CLIENT_ID,
+        redirectUri: FX_OAUTH_WEBCHANNEL_REDIRECT
+      });
+    }
+
     if (mocks) {
       // it's slightly unfortunate that we need to mock the main "internal" object
       // before calling initialize, primarily so a mock `newAccountState` is in

--- a/services/fxaccounts/FxAccounts.jsm
+++ b/services/fxaccounts/FxAccounts.jsm
@@ -134,7 +134,7 @@ XPCOMUtils.defineLazyPreferenceGetter(
 
 XPCOMUtils.defineLazyPreferenceGetter(
   this,
-  "USE_RUST",
+  "RUST_BACKEND",
   "identity.fxaccounts.useRustBackend",
   null,
   null,
@@ -397,15 +397,6 @@ function copyObjectProperties(from, to, thisObj, keys) {
 class FxAccounts {
   constructor(mocks = null) {
     this._internal = new FxAccountsInternal();
-    if (RUST_BACKEND) {
-      // FxAccounts functionality with the Rust backend.
-      this._rustFxAccount = new RustFxAccount({
-        fxaServer: ROOT_URL,
-        clientId: FX_OAUTH_CLIENT_ID,
-        redirectUri: FX_OAUTH_WEBCHANNEL_REDIRECT
-      });
-    }
-
     if (mocks) {
       // it's slightly unfortunate that we need to mock the main "internal" object
       // before calling initialize, primarily so a mock `newAccountState` is in
@@ -465,7 +456,7 @@ class FxAccounts {
    * @returns {RustFxAccount}
    */
   get _rustFxa() {
-    if (USE_RUST) {
+    if (RUST_BACKEND) {
       return this._internal.rustFxa;
     }
     return false;
@@ -925,7 +916,7 @@ FxAccountsInternal.prototype = {
   // All significant initialization should be done in this initialize() method
   // to help with our mocking story.
   initialize() {
-    if (USE_RUST) {
+    if (RUST_BACKEND) {
       let logins = Services.logins.findLogins(
         "chrome://fxarust",
         null,

--- a/services/fxaccounts/FxAccountsCommon.js
+++ b/services/fxaccounts/FxAccountsCommon.js
@@ -88,8 +88,11 @@ exports.COMMAND_SENDTAB = exports.COMMAND_PREFIX + exports.COMMAND_SENDTAB_TAIL;
 
 // OAuth
 exports.FX_OAUTH_CLIENT_ID = "5882386c6d801776";
+exports.FX_OAUTH_WEBCHANNEL_REDIRECT =
+  "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel";
 exports.SCOPE_PROFILE = "profile";
 exports.SCOPE_OLD_SYNC = "https://identity.mozilla.com/apps/oldsync";
+exports.SCOPE_SESSION_TOKEN = "https://identity.mozilla.com/tokens/session";
 
 // OAuth metadata for other Firefox-related services that we might need to know about
 // in order to provide an enhanced user experience.
@@ -112,6 +115,7 @@ exports.COMMAND_PAIR_COMPLETE = "fxaccounts:pair_complete";
 exports.COMMAND_PROFILE_CHANGE = "profile:change";
 exports.COMMAND_CAN_LINK_ACCOUNT = "fxaccounts:can_link_account";
 exports.COMMAND_LOGIN = "fxaccounts:login";
+exports.COMMAND_OAUTH_LOGIN = "fxaccounts:oauth_login";
 exports.COMMAND_LOGOUT = "fxaccounts:logout";
 exports.COMMAND_DELETE = "fxaccounts:delete";
 exports.COMMAND_SYNC_PREFERENCES = "fxaccounts:sync_preferences";

--- a/services/fxaccounts/FxAccountsConfig.jsm
+++ b/services/fxaccounts/FxAccountsConfig.jsm
@@ -75,7 +75,7 @@ var FxAccountsConfig = {
   },
 
   async promiseConnectAccountOAuthURI() {
-    return fxAccounts._rustFxAccount.beginOAuthFlow([SCOPE_PROFILE, SCOPE_OLD_SYNC, SCOPE_SESSION_TOKEN]);
+    return fxAccounts._internal.rustFxa.beginOAuthFlow([SCOPE_PROFILE, SCOPE_OLD_SYNC, SCOPE_SESSION_TOKEN]);
   },
 
   async promiseForceSigninURI(entrypoint, extraParams = {}) {

--- a/services/fxaccounts/FxAccountsConfig.jsm
+++ b/services/fxaccounts/FxAccountsConfig.jsm
@@ -7,7 +7,7 @@ var EXPORTED_SYMBOLS = ["FxAccountsConfig"];
 const { RESTRequest } = ChromeUtils.import(
   "resource://services-common/rest.js"
 );
-const { log } = ChromeUtils.import(
+const { SCOPE_PROFILE, SCOPE_OLD_SYNC, SCOPE_SESSION_TOKEN, log } = ChromeUtils.import(
   "resource://gre/modules/FxAccountsCommon.js"
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
@@ -72,6 +72,10 @@ var FxAccountsConfig = {
         ...extraParams,
       },
     });
+  },
+
+  async promiseConnectAccountOAuthURI() {
+    return fxAccounts._rustFxAccount.beginOAuthFlow([SCOPE_PROFILE, SCOPE_OLD_SYNC, SCOPE_SESSION_TOKEN]);
   },
 
   async promiseForceSigninURI(entrypoint, extraParams = {}) {

--- a/services/fxaccounts/FxAccountsWebChannel.jsm
+++ b/services/fxaccounts/FxAccountsWebChannel.jsm
@@ -18,6 +18,7 @@ const { XPCOMUtils } = ChromeUtils.import(
 const {
   COMMAND_PROFILE_CHANGE,
   COMMAND_LOGIN,
+  COMMAND_OAUTH_LOGIN,
   COMMAND_LOGOUT,
   COMMAND_DELETE,
   COMMAND_CAN_LINK_ACCOUNT,
@@ -244,6 +245,32 @@ FxAccountsWebChannel.prototype = {
           .login(data)
           .catch(error => this._sendError(error, message, sendingContext));
         break;
+      case COMMAND_OAUTH_LOGIN:
+        const rustFxAccount = fxAccounts._rustFxAccount;
+        rustFxAccount
+          .completeOAuthFlow(data.code, data.state)
+          .then(async () => {
+            const profile = await rustFxAccount.getProfile();
+            let state = await rustFxAccount.stateJSON();
+            state = JSON.parse(state);
+            const data = {
+              email: profile.email,
+              services: {},
+              sessionToken: state.session_token,
+              uid: profile.uid,
+              verified: true,
+            }
+
+            return this._helpers.login(data)
+          })
+          .then(() => {
+            // redirect to the sms page to connect more devices
+            browser.loadURI(`${accountServer.spec}sms`, {
+              triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+            })
+          })
+          .catch(error => this._sendError(error, message, sendingContext));
+  break;
       case COMMAND_LOGOUT:
       case COMMAND_DELETE:
         this._helpers

--- a/services/fxaccounts/FxAccountsWebChannel.jsm
+++ b/services/fxaccounts/FxAccountsWebChannel.jsm
@@ -246,7 +246,7 @@ FxAccountsWebChannel.prototype = {
           .catch(error => this._sendError(error, message, sendingContext));
         break;
       case COMMAND_OAUTH_LOGIN:
-        const rustFxAccount = fxAccounts._rustFxAccount;
+        const rustFxAccount = fxAccounts._internal.rustFxa;
         rustFxAccount
           .completeOAuthFlow(data.code, data.state)
           .then(async () => {

--- a/services/fxaccounts/RustFxAccount.js
+++ b/services/fxaccounts/RustFxAccount.js
@@ -4,6 +4,8 @@
 
 const EXPORTED_SYMBOLS = ["RustFxAccount"];
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
 /**
  * This class is a low-level JS wrapper around the `mozIFirefoxAccountsBridge`
  * interface.
@@ -64,7 +66,7 @@ class RustFxAccount {
    * @returns {Promise<string>} The JSON representation of the state.
    */
   async stateJSON() {
-    return promisify(this.bridge.stateJSON);
+    return this._promisify(this.bridge.stateJSON);
   }
   /**
    * Request a OAuth token by starting a new OAuth flow.
@@ -77,7 +79,7 @@ class RustFxAccount {
    * @returns {Promise<string>}  a URL string that the caller should navigate to.
    */
   async beginOAuthFlow(scopes) {
-    return promisify(this.bridge.beginOAuthFlow, scopes);
+    return this._promisify(this.bridge.beginOAuthFlow, scopes);
   }
   /**
    * Complete an OAuth flow initiated by `beginOAuthFlow(...)`.
@@ -87,7 +89,7 @@ class RustFxAccount {
    * @throws if there was an error during the login flow.
    */
   async completeOAuthFlow(code, state) {
-    return promisify(this.bridge.completeOAuthFlow, code, state);
+    return this._promisify(this.bridge.completeOAuthFlow, code, state);
   }
   /**
    * Try to get an OAuth access token.
@@ -112,7 +114,9 @@ class RustFxAccount {
    * the desired scope.
    */
   async getAccessToken(scope, ttl) {
-    return JSON.parse(await promisify(this.bridge.getAccessToken, scope, ttl));
+    return JSON.parse(
+      await this._promisify(this.bridge.getAccessToken, scope, ttl)
+    );
   }
   /**
    * Get the session token if held.
@@ -121,7 +125,7 @@ class RustFxAccount {
    * @throws if a session token is not being held.
    */
   async getSessionToken() {
-    return promisify(this.bridge.getSessionToken);
+    return this._promisify(this.bridge.getSessionToken);
   }
   /**
    * Returns the list of OAuth attached clients.
@@ -144,7 +148,7 @@ class RustFxAccount {
    * @throws if a session token is not being held.
    */
   async getAttachedClients() {
-    return JSON.parse(await promisify(this.bridge.getAttachedClients));
+    return JSON.parse(await this._promisify(this.bridge.getAttachedClients));
   }
   /**
    * Check whether the currently held refresh token is active.
@@ -155,7 +159,9 @@ class RustFxAccount {
    * @returns {Promise<IntrospectInfo>}
    */
   async checkAuthorizationStatus() {
-    return JSON.parse(await promisify(this.bridge.checkAuthorizationStatus));
+    return JSON.parse(
+      await this._promisify(this.bridge.checkAuthorizationStatus)
+    );
   }
   /*
    * This method should be called when a request made with
@@ -165,14 +171,14 @@ class RustFxAccount {
    * again.
    */
   async clearAccessTokenCache() {
-    return promisify(this.bridge.clearAccessTokenCache);
+    return this._promisify(this.bridge.clearAccessTokenCache);
   }
   /*
    * Disconnect from the account and optionaly destroy our device record.
    * `beginOAuthFlow(...)` will need to be called to reconnect.
    */
   async disconnect() {
-    return promisify(this.bridge.disconnect);
+    return this._promisify(this.bridge.disconnect);
   }
   /**
    * Gets the logged-in user profile.
@@ -191,7 +197,9 @@ class RustFxAccount {
    * at least the `profile` scope.
    */
   async getProfile(ignoreCache) {
-    return JSON.parse(await promisify(this.bridge.getProfile, ignoreCache));
+    return JSON.parse(
+      await this._promisify(this.bridge.getProfile, ignoreCache)
+    );
   }
   /**
    * Start a migration process from a session-token-based authenticated account.
@@ -212,7 +220,7 @@ class RustFxAccount {
     copySessionToken = false
   ) {
     return JSON.parse(
-      await promisify(
+      await this._promisify(
         this.bridge.migrateFromSessionToken,
         sessionToken,
         kSync,
@@ -228,7 +236,7 @@ class RustFxAccount {
    */
   async retryMigrateFromSessionToken() {
     return JSON.parse(
-      await promisify(this.bridge.retryMigrateFromSessionToken)
+      await this._promisify(this.bridge.retryMigrateFromSessionToken)
     );
   }
   /**
@@ -238,7 +246,7 @@ class RustFxAccount {
    * @returns {Promise<boolean>} true if a migration flow can be resumed.
    */
   async isInMigrationState() {
-    return promisify(this.bridge.isInMigrationState);
+    return this._promisify(this.bridge.isInMigrationState);
   }
   /**
    * Called after a password change was done through webchannel.
@@ -246,7 +254,7 @@ class RustFxAccount {
    * @param {string} sessionToken
    */
   async handleSessionTokenChange(sessionToken) {
-    return promisify(this.bridge.handleSessionTokenChange, sessionToken);
+    return this._promisify(this.bridge.handleSessionTokenChange, sessionToken);
   }
   /**
    * Get the token server URL with `1.0/sync/1.5` appended at the end.
@@ -254,28 +262,28 @@ class RustFxAccount {
    * @returns {Promise<string>}
    */
   async getTokenServerEndpointURL() {
-    let url = await promisify(this.bridge.getTokenServerEndpointURL);
+    let url = await this._promisify(this.bridge.getTokenServerEndpointURL);
     return `${url}${url.endsWith("/") ? "" : "/"}1.0/sync/1.5`;
   }
   /**
    * @returns {Promise<string>}
    */
   async getConnectionSuccessURL() {
-    return promisify(this.bridge.getConnectionSuccessURL);
+    return this._promisify(this.bridge.getConnectionSuccessURL);
   }
   /**
    * @param {string} entrypoint
    * @returns {Promise<string>}
    */
   async getManageAccountURL(entrypoint) {
-    return promisify(this.bridge.getManageAccountURL, entrypoint);
+    return this._promisify(this.bridge.getManageAccountURL, entrypoint);
   }
   /**
    * @param {string} entrypoint
    * @returns {Promise<string>}
    */
   async getManageDevicesURL(entrypoint) {
-    return promisify(this.bridge.getManageDevicesURL, entrypoint);
+    return this._promisify(this.bridge.getManageDevicesURL, entrypoint);
   }
   /**
    * Fetch the devices in the account.
@@ -302,7 +310,9 @@ class RustFxAccount {
    * @returns {Promise<[Device]>}
    */
   async fetchDevices(ignoreCache) {
-    return JSON.parse(await promisify(this.bridge.fetchDevices, ignoreCache));
+    return JSON.parse(
+      await this._promisify(this.bridge.fetchDevices, ignoreCache)
+    );
   }
   /**
    * Rename the local device
@@ -310,7 +320,7 @@ class RustFxAccount {
    * @param {string} name
    */
   async setDeviceDisplayName(name) {
-    return promisify(this.bridge.setDeviceDisplayName, name);
+    return this._promisify(this.bridge.setDeviceDisplayName, name);
   }
   /**
    * Handle an incoming Push message payload.
@@ -326,7 +336,9 @@ class RustFxAccount {
    * @return {Promise<[TabReceivedCommand|DeviceConnectedEvent|DeviceDisconnectedEvent]>}
    */
   async handlePushMessage(payload) {
-    return JSON.parse(await promisify(this.bridge.handlePushMessage, payload));
+    return JSON.parse(
+      await this._promisify(this.bridge.handlePushMessage, payload)
+    );
   }
   /**
    * Fetch for device commands we didn't receive through Push.
@@ -342,7 +354,7 @@ class RustFxAccount {
    * @returns {Promise<[TabReceivedCommand]>}
    */
   async pollDeviceCommands() {
-    return JSON.parse(await promisify(this.bridge.pollDeviceCommands));
+    return JSON.parse(await this._promisify(this.bridge.pollDeviceCommands));
   }
   /**
    * Send a tab to a device identified by its ID.
@@ -352,7 +364,7 @@ class RustFxAccount {
    * @param {string} url
    */
   async sendSingleTab(targetId, title, url) {
-    return promisify(this.bridge.sendSingleTab, targetId, title, url);
+    return this._promisify(this.bridge.sendSingleTab, targetId, title, url);
   }
   /**
    * Update our FxA push subscription.
@@ -362,7 +374,7 @@ class RustFxAccount {
    * @param {string} authKey
    */
   async setDevicePushSubscription(endpoint, publicKey, authKey) {
-    return promisify(
+    return this._promisify(
       this.bridge.setDevicePushSubscription,
       endpoint,
       publicKey,
@@ -377,7 +389,7 @@ class RustFxAccount {
    * @param {[DeviceCapability]} supportedCapabilities
    */
   async initializeDevice(name, deviceType, supportedCapabilities) {
-    return promisify(
+    return this._promisify(
       this.bridge.initializeDevice,
       name,
       deviceType,
@@ -390,23 +402,66 @@ class RustFxAccount {
    * @param {[DeviceCapability]} supportedCapabilities
    */
   async ensureCapabilities(supportedCapabilities) {
-    return promisify(this.bridge.ensureCapabilities, supportedCapabilities);
+    return this._promisify(
+      this.bridge.ensureCapabilities,
+      supportedCapabilities
+    );
   }
-}
 
-function promisify(func, ...params) {
-  return new Promise((resolve, reject) => {
-    func(...params, {
-      // This object implicitly implements
-      // `mozIFirefoxAccountsBridgeCallback`.
-      handleSuccess: resolve,
-      handleError(code, message) {
-        let error = new Error(message);
-        error.result = code;
-        reject(error);
-      },
+  _promisify(func, ...params) {
+    const fxa = this;
+    return new Promise((resolve, reject) => {
+      func(...params, {
+        // This object implicitly implements
+        // `mozIFirefoxAccountsBridgeCallback`.
+        handleSuccess(res) {
+          // Get and write the FxA state.
+          // Very much prototype quality code.
+          // There's a high chance the JS event loop will mess up everything,
+          // such as doing OP1 "write-state" AFTER OP2 "write-state".
+          fxa.bridge.stateJSON({
+            // Who doesn't like recursion?
+            handleSuccess(state) {
+              let loginInfo = new Components.Constructor(
+                "@mozilla.org/login-manager/loginInfo;1",
+                Ci.nsILoginInfo,
+                "init"
+              );
+              let login = new loginInfo(
+                "chrome://fxarust",
+                null, // aFormActionOrigin,
+                "FxA Rust state", // aHttpRealm,
+                "fxarust", // aUsername
+                state, // aPassword
+                "", // aUsernameField
+                ""
+              ); // aPasswordField
+
+              let existingLogins = Services.logins.findLogins(
+                "chrome://fxarust",
+                null,
+                "FxA Rust state"
+              );
+              if (existingLogins.length) {
+                Services.logins.modifyLogin(existingLogins[0], login);
+              } else {
+                Services.logins.addLogin(login);
+              }
+            },
+            handleError(code, message) {
+              // Something went wrong.
+            },
+          });
+          resolve(res);
+        },
+        handleError(code, message) {
+          let error = new Error(message);
+          error.result = code;
+          reject(error);
+        },
+      });
     });
-  });
+  }
 }
 
 /**

--- a/services/fxaccounts/RustFxAccount.js
+++ b/services/fxaccounts/RustFxAccount.js
@@ -4,8 +4,6 @@
 
 const EXPORTED_SYMBOLS = ["RustFxAccount"];
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 /**
  * This class is a low-level JS wrapper around the `mozIFirefoxAccountsBridge`
  * interface.
@@ -66,7 +64,7 @@ class RustFxAccount {
    * @returns {Promise<string>} The JSON representation of the state.
    */
   async stateJSON() {
-    return this._promisify(this.bridge.stateJSON);
+    return promisify(this.bridge.stateJSON);
   }
   /**
    * Request a OAuth token by starting a new OAuth flow.
@@ -79,7 +77,7 @@ class RustFxAccount {
    * @returns {Promise<string>}  a URL string that the caller should navigate to.
    */
   async beginOAuthFlow(scopes) {
-    return this._promisify(this.bridge.beginOAuthFlow, scopes);
+    return promisify(this.bridge.beginOAuthFlow, scopes);
   }
   /**
    * Complete an OAuth flow initiated by `beginOAuthFlow(...)`.
@@ -89,7 +87,7 @@ class RustFxAccount {
    * @throws if there was an error during the login flow.
    */
   async completeOAuthFlow(code, state) {
-    return this._promisify(this.bridge.completeOAuthFlow, code, state);
+    return promisify(this.bridge.completeOAuthFlow, code, state);
   }
   /**
    * Try to get an OAuth access token.
@@ -114,9 +112,7 @@ class RustFxAccount {
    * the desired scope.
    */
   async getAccessToken(scope, ttl) {
-    return JSON.parse(
-      await this._promisify(this.bridge.getAccessToken, scope, ttl)
-    );
+    return JSON.parse(await promisify(this.bridge.getAccessToken, scope, ttl));
   }
   /**
    * Get the session token if held.
@@ -125,7 +121,7 @@ class RustFxAccount {
    * @throws if a session token is not being held.
    */
   async getSessionToken() {
-    return this._promisify(this.bridge.getSessionToken);
+    return promisify(this.bridge.getSessionToken);
   }
   /**
    * Returns the list of OAuth attached clients.
@@ -148,7 +144,7 @@ class RustFxAccount {
    * @throws if a session token is not being held.
    */
   async getAttachedClients() {
-    return JSON.parse(await this._promisify(this.bridge.getAttachedClients));
+    return JSON.parse(await promisify(this.bridge.getAttachedClients));
   }
   /**
    * Check whether the currently held refresh token is active.
@@ -159,9 +155,7 @@ class RustFxAccount {
    * @returns {Promise<IntrospectInfo>}
    */
   async checkAuthorizationStatus() {
-    return JSON.parse(
-      await this._promisify(this.bridge.checkAuthorizationStatus)
-    );
+    return JSON.parse(await promisify(this.bridge.checkAuthorizationStatus));
   }
   /*
    * This method should be called when a request made with
@@ -171,14 +165,14 @@ class RustFxAccount {
    * again.
    */
   async clearAccessTokenCache() {
-    return this._promisify(this.bridge.clearAccessTokenCache);
+    return promisify(this.bridge.clearAccessTokenCache);
   }
   /*
    * Disconnect from the account and optionaly destroy our device record.
    * `beginOAuthFlow(...)` will need to be called to reconnect.
    */
   async disconnect() {
-    return this._promisify(this.bridge.disconnect);
+    return promisify(this.bridge.disconnect);
   }
   /**
    * Gets the logged-in user profile.
@@ -197,9 +191,7 @@ class RustFxAccount {
    * at least the `profile` scope.
    */
   async getProfile(ignoreCache) {
-    return JSON.parse(
-      await this._promisify(this.bridge.getProfile, ignoreCache)
-    );
+    return JSON.parse(await promisify(this.bridge.getProfile, ignoreCache));
   }
   /**
    * Start a migration process from a session-token-based authenticated account.
@@ -220,7 +212,7 @@ class RustFxAccount {
     copySessionToken = false
   ) {
     return JSON.parse(
-      await this._promisify(
+      await promisify(
         this.bridge.migrateFromSessionToken,
         sessionToken,
         kSync,
@@ -236,7 +228,7 @@ class RustFxAccount {
    */
   async retryMigrateFromSessionToken() {
     return JSON.parse(
-      await this._promisify(this.bridge.retryMigrateFromSessionToken)
+      await promisify(this.bridge.retryMigrateFromSessionToken)
     );
   }
   /**
@@ -246,7 +238,7 @@ class RustFxAccount {
    * @returns {Promise<boolean>} true if a migration flow can be resumed.
    */
   async isInMigrationState() {
-    return this._promisify(this.bridge.isInMigrationState);
+    return promisify(this.bridge.isInMigrationState);
   }
   /**
    * Called after a password change was done through webchannel.
@@ -254,7 +246,7 @@ class RustFxAccount {
    * @param {string} sessionToken
    */
   async handleSessionTokenChange(sessionToken) {
-    return this._promisify(this.bridge.handleSessionTokenChange, sessionToken);
+    return promisify(this.bridge.handleSessionTokenChange, sessionToken);
   }
   /**
    * Get the token server URL with `1.0/sync/1.5` appended at the end.
@@ -262,28 +254,28 @@ class RustFxAccount {
    * @returns {Promise<string>}
    */
   async getTokenServerEndpointURL() {
-    let url = await this._promisify(this.bridge.getTokenServerEndpointURL);
+    let url = await promisify(this.bridge.getTokenServerEndpointURL);
     return `${url}${url.endsWith("/") ? "" : "/"}1.0/sync/1.5`;
   }
   /**
    * @returns {Promise<string>}
    */
   async getConnectionSuccessURL() {
-    return this._promisify(this.bridge.getConnectionSuccessURL);
+    return promisify(this.bridge.getConnectionSuccessURL);
   }
   /**
    * @param {string} entrypoint
    * @returns {Promise<string>}
    */
   async getManageAccountURL(entrypoint) {
-    return this._promisify(this.bridge.getManageAccountURL, entrypoint);
+    return promisify(this.bridge.getManageAccountURL, entrypoint);
   }
   /**
    * @param {string} entrypoint
    * @returns {Promise<string>}
    */
   async getManageDevicesURL(entrypoint) {
-    return this._promisify(this.bridge.getManageDevicesURL, entrypoint);
+    return promisify(this.bridge.getManageDevicesURL, entrypoint);
   }
   /**
    * Fetch the devices in the account.
@@ -310,9 +302,7 @@ class RustFxAccount {
    * @returns {Promise<[Device]>}
    */
   async fetchDevices(ignoreCache) {
-    return JSON.parse(
-      await this._promisify(this.bridge.fetchDevices, ignoreCache)
-    );
+    return JSON.parse(await promisify(this.bridge.fetchDevices, ignoreCache));
   }
   /**
    * Rename the local device
@@ -320,7 +310,7 @@ class RustFxAccount {
    * @param {string} name
    */
   async setDeviceDisplayName(name) {
-    return this._promisify(this.bridge.setDeviceDisplayName, name);
+    return promisify(this.bridge.setDeviceDisplayName, name);
   }
   /**
    * Handle an incoming Push message payload.
@@ -336,9 +326,7 @@ class RustFxAccount {
    * @return {Promise<[TabReceivedCommand|DeviceConnectedEvent|DeviceDisconnectedEvent]>}
    */
   async handlePushMessage(payload) {
-    return JSON.parse(
-      await this._promisify(this.bridge.handlePushMessage, payload)
-    );
+    return JSON.parse(await promisify(this.bridge.handlePushMessage, payload));
   }
   /**
    * Fetch for device commands we didn't receive through Push.
@@ -354,7 +342,7 @@ class RustFxAccount {
    * @returns {Promise<[TabReceivedCommand]>}
    */
   async pollDeviceCommands() {
-    return JSON.parse(await this._promisify(this.bridge.pollDeviceCommands));
+    return JSON.parse(await promisify(this.bridge.pollDeviceCommands));
   }
   /**
    * Send a tab to a device identified by its ID.
@@ -364,7 +352,7 @@ class RustFxAccount {
    * @param {string} url
    */
   async sendSingleTab(targetId, title, url) {
-    return this._promisify(this.bridge.sendSingleTab, targetId, title, url);
+    return promisify(this.bridge.sendSingleTab, targetId, title, url);
   }
   /**
    * Update our FxA push subscription.
@@ -374,7 +362,7 @@ class RustFxAccount {
    * @param {string} authKey
    */
   async setDevicePushSubscription(endpoint, publicKey, authKey) {
-    return this._promisify(
+    return promisify(
       this.bridge.setDevicePushSubscription,
       endpoint,
       publicKey,
@@ -389,7 +377,7 @@ class RustFxAccount {
    * @param {[DeviceCapability]} supportedCapabilities
    */
   async initializeDevice(name, deviceType, supportedCapabilities) {
-    return this._promisify(
+    return promisify(
       this.bridge.initializeDevice,
       name,
       deviceType,
@@ -402,66 +390,23 @@ class RustFxAccount {
    * @param {[DeviceCapability]} supportedCapabilities
    */
   async ensureCapabilities(supportedCapabilities) {
-    return this._promisify(
-      this.bridge.ensureCapabilities,
-      supportedCapabilities
-    );
+    return promisify(this.bridge.ensureCapabilities, supportedCapabilities);
   }
+}
 
-  _promisify(func, ...params) {
-    const fxa = this;
-    return new Promise((resolve, reject) => {
-      func(...params, {
-        // This object implicitly implements
-        // `mozIFirefoxAccountsBridgeCallback`.
-        handleSuccess(res) {
-          // Get and write the FxA state.
-          // Very much prototype quality code.
-          // There's a high chance the JS event loop will mess up everything,
-          // such as doing OP1 "write-state" AFTER OP2 "write-state".
-          fxa.bridge.stateJSON({
-            // Who doesn't like recursion?
-            handleSuccess(state) {
-              let loginInfo = new Components.Constructor(
-                "@mozilla.org/login-manager/loginInfo;1",
-                Ci.nsILoginInfo,
-                "init"
-              );
-              let login = new loginInfo(
-                "chrome://fxarust",
-                null, // aFormActionOrigin,
-                "FxA Rust state", // aHttpRealm,
-                "fxarust", // aUsername
-                state, // aPassword
-                "", // aUsernameField
-                ""
-              ); // aPasswordField
-
-              let existingLogins = Services.logins.findLogins(
-                "chrome://fxarust",
-                null,
-                "FxA Rust state"
-              );
-              if (existingLogins.length) {
-                Services.logins.modifyLogin(existingLogins[0], login);
-              } else {
-                Services.logins.addLogin(login);
-              }
-            },
-            handleError(code, message) {
-              // Something went wrong.
-            },
-          });
-          resolve(res);
-        },
-        handleError(code, message) {
-          let error = new Error(message);
-          error.result = code;
-          reject(error);
-        },
-      });
+function promisify(func, ...params) {
+  return new Promise((resolve, reject) => {
+    func(...params, {
+      // This object implicitly implements
+      // `mozIFirefoxAccountsBridgeCallback`.
+      handleSuccess: resolve,
+      handleError(code, message) {
+        let error = new Error(message);
+        error.result = code;
+        reject(error);
+      },
     });
-  }
+  });
 }
 
 /**

--- a/services/fxaccounts/tests/xpcshell/test_accounts.js
+++ b/services/fxaccounts/tests/xpcshell/test_accounts.js
@@ -1031,7 +1031,7 @@ add_test(function test_fetchAndUnwrapKeys_no_token() {
   fxa
     .setSignedInUser(user)
     .then(user2 => {
-      return fxa.keys.fetchAndUnwrapKeys();
+      return fxa.keys._fetchAndUnwrapKeys();
     })
     .catch(error => {
       log.info("setSignedInUser correctly rejected");

--- a/services/fxaccounts/tests/xpcshell/test_rust_account.js
+++ b/services/fxaccounts/tests/xpcshell/test_rust_account.js
@@ -1,0 +1,24 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const ROOT_URL = "https://accounts.firefox.com";
+const FX_OAUTH_CLIENT_ID = "5882386c6d801776";
+const FX_OAUTH_WEBCHANNEL_REDIRECT =
+  "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel";
+const PROFILE_SCOPE = "profile";
+
+const { RustFxAccount } = ChromeUtils.import(
+  "resource://gre/modules/RustFxAccount.js"
+);
+
+add_task(async function test_begin_oauth_flow() {
+  let bridge = new RustFxAccount({
+    fxaServer: ROOT_URL,
+    clientId: FX_OAUTH_CLIENT_ID,
+    redirectUri: FX_OAUTH_WEBCHANNEL_REDIRECT,
+  });
+  let flow = await bridge.beginOAuthFlow([PROFILE_SCOPE]);
+  Assert.ok(flow);
+});

--- a/services/fxaccounts/tests/xpcshell/xpcshell.ini
+++ b/services/fxaccounts/tests/xpcshell/xpcshell.ini
@@ -22,6 +22,7 @@ support-files =
 [test_rust_fxaccount.js]
 [test_push_service.js]
 [test_telemetry.js]
+[test_rust_account.js]
 [test_web_channel.js]
 [test_profile.js]
 [test_storage_manager.js]

--- a/services/sync/modules/browserid_identity.js
+++ b/services/sync/modules/browserid_identity.js
@@ -65,7 +65,14 @@ XPCOMUtils.defineLazyPreferenceGetter(
 XPCOMUtils.defineLazyPreferenceGetter(
   this,
   "USE_OAUTH_FOR_SYNC_TOKEN",
-  "identity.sync.useOAuthForSyncToken"
+  "identity.sync.useOAuthForSyncToken",
+  null,
+  null,
+  // No matter what, activating the Rust backend should activate the OAuth fetching for keys.
+  val =>
+    Services.prefs.getBoolPref("identity.fxaccounts.useExperimentalRustClient")
+      ? true
+      : val
 );
 
 // FxAccountsCommon.js doesn't use a "namespace", so create one here.

--- a/services/sync/tests/unit/test_browserid_identity.js
+++ b/services/sync/tests/unit/test_browserid_identity.js
@@ -812,7 +812,7 @@ add_task(async function test_getKeysMissing() {
     },
     // And the keys object with a mock that returns no keys.
     keys: {
-      fetchAndUnwrapKeys() {
+      _fetchAndUnwrapKeys() {
         return Promise.resolve({});
       },
     },
@@ -855,7 +855,7 @@ add_task(async function test_signedInUserMissing() {
   configureFxAccountIdentity(browseridManager, globalIdentityConfig);
 
   let fxa = new FxAccounts({
-    fetchAndUnwrapKeys() {
+    _fetchAndUnwrapKeys() {
       return Promise.resolve({});
     },
     fxAccountsClient: new MockFxAccountsClient(),

--- a/xpcom/build/Services.py
+++ b/xpcom/build/Services.py
@@ -58,6 +58,8 @@ service('Bits', 'nsIBits',
 # NB: this should also expose nsIXULAppInfo, as does Services.jsm.
 service('AppInfoService', 'nsIXULRuntime',
         "@mozilla.org/xre/app-info;1")
+service('Logins', 'nsILoginManager',
+        "@mozilla.org/login-manager;1")
 
 if buildconfig.substs.get('ENABLE_REMOTE_AGENT'):
     service('RemoteAgent', 'nsIRemoteAgent',
@@ -96,6 +98,7 @@ CPP_INCLUDES = """
 #include "nsIURIFixup.h"
 #include "nsIBits.h"
 #include "nsIXULRuntime.h"
+#include "nsILoginManager.h"
 """
 
 if buildconfig.substs.get('ENABLE_REMOTE_AGENT'):


### PR DESCRIPTION
This is a WIP patch that keeps the `FxAccount` and friends API intact while using the Rust backend if  the `identity.fxaccounts.useExperimentalRustClient` pref is present.

It's **very much** prototype quality, but I think it could be a good start. So far I've been able to show the profile info in the UI and trigger a sync. Device stuff is not working yet though.

How do you feel @mhammond @vladikoff @lougeniaC64 about contributing to this branch to achieve the M3 milestone? (maybe we could make PRs against this PR). (I didn't touch #1 since there seem to be rebase problems there)